### PR TITLE
misspelled "category"

### DIFF
--- a/seller/authentication/note.md
+++ b/seller/authentication/note.md
@@ -1,1 +1,1 @@
-## Catagory
+## Category


### PR DESCRIPTION
changed the spelling of the work "catagory" to "category".